### PR TITLE
Re-integration of *conditional* IR support code

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Monitoring a recifal aquarium with arduino, and sending alerts by SMS
 
 Monitors light and temperature, and sends an SMS to a pre defined mobile phone number when configurable thresholds are reached.
 
-The WihoutIR branch is a test to check how much emory is saved by removing IR support. About 10k
+The WihoutIR branch is a test to check how much emory is saved by removing IR support: About 7k
+That should be enough to start working on RTC integration + schedule.
+All settings will be made available through incoming SMS processing
 <del>Thresholds (and other stuff) can be configured with an IR remote control.</del>
 
 Can also respond to SMS sent to it, according to their contents.
@@ -29,13 +31,15 @@ When complete, will probably not fit on Arduino UNO.
 * Most strings stored in PROGMEM to save variable space. But a Mega will be necessary...
 
 # TODOs
+* handle incoming SMS for all seetings
+* smart configuration saving to EEPROM (not each time, within a delay after a modification, on request per SMS...)
 * RTC with onboard battery to handle lighting time schedule and not send SMS just because lights are off when they should be
 * water level detection to warn about evaporation compensation failure
 * water movement detection to warn about pumps failure (sensor remains to be found...) 
 * centralized LCD message display to insure transient messages display and removal
-* backuped power (and alert) in case of power failure
-* Saving periodical measure data on SD card (and may be info about sent and received SMS)
-* Change configuration using inbound SMS: thresholds, activation/deactivation of alerting feature, ...
+* backuped power (and alerting) in case of power failure
+* Loging: save periodical measure data to SD card (and may be also info about sent and received SMS)
+
 
 #Licence
 ...to kill.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ Monitoring a recifal aquarium with arduino, and sending alerts by SMS
 
 Monitors light and temperature, and sends an SMS to a pre defined mobile phone number when configurable thresholds are reached.
 
-Thresholds (and other stuff) can be configured with an IR remote control.
+The WihoutIR branch is a test to check how much emory is saved by removing IR support. About 10k
+<del>Thresholds (and other stuff) can be configured with an IR remote control.</del>
 
 Can also respond to SMS sent to it, according to their contents.
 
@@ -15,10 +16,10 @@ When complete, will probably not fit on Arduino UNO.
 * Light periodical measurement
 * LCD display of these measures
 * Sending SMS with light and temperature when thresholds are reached
-* Adjusting the low light alarm threshold by IR remote control & LCD display
+<del>* Adjusting the low light alarm threshold by IR remote control & LCD display
 * Adjusting the temperature value by IR remote control & LCD display
 * Displaying the (hardcoded) low and high temperature alarm thresholds by IR remote control & LCD display
-* Displaying the (hardocded) SMS recipient phone number by IR remote control & LCD display
+* Displaying the (hardocded) SMS recipient phone number by IR remote control & LCD display</del>
 * Limitation on how often alarm SMS can be sent (still hardcoded)
 * Periodical checking for incoming SMS
   * 'status': send SMS back with current measures

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ When complete, will probably not fit on Arduino UNO.
 * Light periodical measurement
 * LCD display of these measures
 * Sending SMS with light and temperature when thresholds are reached
-<del>* Adjusting the low light alarm threshold by IR remote control & LCD display
-* Adjusting the temperature value by IR remote control & LCD display
-* Displaying the (hardcoded) low and high temperature alarm thresholds by IR remote control & LCD display
-* Displaying the (hardocded) SMS recipient phone number by IR remote control & LCD display</del>
+* <del>Adjusting the low light alarm threshold by IR remote control & LCD display</del>
+* <del>Adjusting the temperature value by IR remote control & LCD display</del>
+* <del>Displaying the (hardcoded) low and high temperature alarm thresholds by IR remote control & LCD display</del>
+* <del>Displaying the (hardocded) SMS recipient phone number by IR remote control & LCD display</del>
 * Limitation on how often alarm SMS can be sent (still hardcoded)
 * Periodical checking for incoming SMS
   * 'status': send SMS back with current measures

--- a/aquaMonitor.ino
+++ b/aquaMonitor.ino
@@ -1,35 +1,89 @@
+// BOF preprocessor bug prevent - insert me on top of your arduino-code
+#if 1
+__asm volatile ("nop");
+#endif
+
 #include <OneWire.h>
-#include <LiquidCrystal.h>
 #include <GSM.h>
 #include <EEPROMex.h>
 #include <EEPROMvar.h>
+#include <Wire.h>
+#include "DS1307.h"
+
+
+// 'admin' phone number defined outside of open source file haha !
+#include <remoteNumber.h>
+
+// Compilation directives to enable/disable stuff like IR support
+// Beware, 'includes' for the matching libraries need to be commented / uncommented
+// In the first #if using these flags
+#define WITH_IR_SUPPORT false      // About 7k prog, 200B RAM
+#define WITH_LCD_SUPPORT true      // About 1,6k prog, 30B RAM
+
+
+// Strings to store in progmem space to free variable space
+#include "./progmemStrings.h"
 
 #define PHONE_NUMBER_LENGTH 15
 #define MAX_PHONE_NUMBERS 4
 #define CONFIG_ADDRESS 0
 
 // Change this version to reset the EEPROM saved configuration
-// when either the structure or default values change
-#define CONFIG_VERSION 3
+// when the structure changes
+#define CONFIG_VERSION 4
 
 struct phoneConfig {
-  unsigned char serviceFlags;
+  unsigned char permissionFlags;
   char number[PHONE_NUMBER_LENGTH + 1];
+  unsigned long lastAlertSmsTime;  // When was last time (millis()) an alert SMS sent to that number
+  unsigned long minAlertInterval;  // minimum interval in seconds between 2 alert SMS to avoir flooding 
 };
 
 struct eepromConfig {
-  unsigned char version;
-  int temperatureAdjustment;
-  int temperatureHighThreshold;
-  int temperatureLowThreshold;
-  int lightThreshold;
-  phoneConfig registeredNumbers[MAX_PHONE_NUMBERS];
+  unsigned int version;          // Version for this config structure and default values. Always keep as first structure member 
+  int temperatureAdjustment;     // Signed offset to add to temperature measure to adjust it
+  int temperatureHighThreshold;  // Alert will be sent if temperature above this value (centiCelsius: 2550 is 25,50°)
+  int temperatureLowThreshold;   // Alert will be sent if temperature below this value (centiCelsius: 2400 is 24°)
+  int lightThreshold;            // Alert will be sent if light below this value within on/off hours (see below)
+  byte lightOnHour;              // Hour after which light should be above the threshold
+  byte lightOnMinute;            // Minute ...
+  byte lightOffHour;             // Hour after which light below threshold won't be considered an alert
+  byte lightOffMinute;           // Minute ...
+  phoneConfig registeredNumbers[MAX_PHONE_NUMBERS];  // Phone numbers to send alerts to, according to their subscriptions and permissions
 } config;
 
+// Flags for services subscriptions and permissions
 #define FLAG_SERVICE_ALERT   0x01
 #define FLAG_SERVICE_EVENT   0x02
 #define FLAG_SERVICE_SUB     0x04
 #define FLAG_SERVICE_UNSUB   0x08
+#define FLAG_ADMIN           0x80
+
+#if WITH_IR_SUPPORT
+// #include are processed no matter what (known bug) : comment or uncomment them is the only way
+//#include <IRremote.h>
+// Init IR
+#define IR_PIN 5
+IRrecv reception_ir(IR_PIN);
+
+// These are the codes sent by Remote used to trigger stuff. Replace with your own
+// TODO: Some future feature may need a sequence of keys. Not handled for now
+#define IR_DISPLAY_PHONE_NUMBER 0xF720DF       // (R key on xanlite remote, for now)
+#define IR_INCR_LIGHT_THRESHOLD 0xF700FF       // (light+ on xanlite remote, for now)
+#define IR_DECR_LIGHT_THRESHOLD 0xF7807F       // (light- on xanlite remote, for now)
+#define IR_INCR_TEMP_ADJUSTMENT 0xF740BF       // (OFF on xanlite remote, for now)
+#define IR_DECR_TEMP_ADJUSTMENT 0xF7C03F       // (ON on xanlite remote, for now)
+#define IR_DISPLAY_THRESHOLDS   0xF7A05F       // (V on xanlite remote, for now)
+#define IR_DISPLAY_TEMP_ADJUST  0xF7609F       // (B on xanlite remote, for now)
+#define IR_SAVE_TO_EEPROM       0xF7E817    // ('Lent' on xanlite remote, for now)
+#define IR_LOG_CONFIG           0xF728D7    // jaune clair
+// When a key is maintained pressed, a different code is sent, and we want to repeat the operation
+#define IR_REPEAT_CODE 0xFFFFFFFF
+unsigned long previousCode = 0;
+
+#define IR_DISPLAY_TIMEOUT 250
+unsigned long lastIrDisplay = 0;
+#endif
 
 // GSM
 // initialize the library instance
@@ -37,15 +91,16 @@ struct eepromConfig {
 GSM gsmAccess; // include a 'true' parameter for debug enabled
 GSM_SMS sms;
 
-// defined in a private file haha !
-#include <remoteNumber.h>
-
 // LCD
+#if WITH_LCD_SUPPORT
+// #include are processed no matter what (known bug) : comment or uncomment them is the only way
+#include <LiquidCrystal.h>
 // initialize the library with the interface pins
 LiquidCrystal lcd(7, 8, 9, 10, 11 , 12);
-
 #define LCD_WIDTH 16
 #define LCD_HEIGHT 2
+#endif
+
 #define MSG_MAX_LENGTH 14
 
 #define LIGHT_PIN 0
@@ -80,15 +135,33 @@ unsigned long lastSmsSent = 0;
 boolean gsmEnabled = !false;
 
 boolean statusOK = true;
-#include "./progmemStrings.h"
 
+DS1307 clock; // The RTC handle to get date
+
+// System initialization
 void setup(void) {
   Serial.begin(9600);
-  EEPROM.setMaxAllowedWrites(10);
+
+  // Just in case some loop goes crazy, limit the number of EEPROM writes to save it
+  // TODO : this should be removed some day
+  EEPROM.setMaxAllowedWrites(100);
+
+  // Initialise RTC
+  clock.begin();
+ 
+#if WITH_LCD_SUPPORT
   lcd.begin(LCD_WIDTH, LCD_HEIGHT,1);
+  lcd.clear();
+#endif
 
   print(0, 0, getProgMemMsg(INIT_AQUAMON_MSG));
   readConfig();
+
+#if WITH_IR_SUPPORT
+  print(0, 1, getProgMemMsg(INIT_IR_MSG));
+  reception_ir.enableIRIn(); // init receiver
+  delay(250);
+#endif
 
   print(0, 1, getProgMemMsg(TEMP_INIT_MSG));
   if (!ds.search(addr[0]))
@@ -105,7 +178,6 @@ void setup(void) {
   boolean notConnected = true && gsmEnabled;
 
   // Start GSM shield
-  lcd.clear();
   print(0, 0, getProgMemMsg(INIT_GSM_MSG));
   while(notConnected)
   {
@@ -119,7 +191,9 @@ void setup(void) {
     }
   }
   delay(500);
+#if WITH_LCD_SUPPORT
   lcd.clear();
+#endif
 }
 
 // Returns pointer to the global string buffer holding a string read from PROGMEM
@@ -131,29 +205,59 @@ char * getProgMemMsg(int messageId) {
 }
 
 void loop(void) {
+  // RTC does not have an epoch field :(
   unsigned long now = millis();
 
-  if((now - lastLightCheck) >= LIGHT_CHECK_PERIOD) {
+#if WITH_IR_SUPPORT
+  decode_results code;
+
+  // Check if an IR code was received
+  if (reception_ir.decode(&code)) {
+    processIRCode(code.value);
+    reception_ir.resume(); // be ready for next code
+  }
+  if((now - lastIrDisplay) >= IR_DISPLAY_TIMEOUT) {
+    resetIRDisplay();
+  }
+#endif
+
+  if(checkElapsedDelay(now, lastLightCheck, LIGHT_CHECK_PERIOD)) {
     statusOK = statusOK && checkLight();
     lastLightCheck = now;
   }
-  if((now - lastTemperatureCheck) >= TEMPERATURE_CHECK_PERIOD) {
+  if(checkElapsedDelay(now, lastTemperatureCheck, TEMPERATURE_CHECK_PERIOD)) {
     statusOK = statusOK && checkTemperature();
     lastTemperatureCheck = millis();
   }
-
-  if((now - lastSmsCheck) >= SMS_CHECK_PERIOD) {
+  if(checkElapsedDelay(now, lastSmsCheck, SMS_CHECK_PERIOD)) {
     checkSMS();
     lastSmsCheck = now;
   }
 
-  if(!statusOK && (now - lastSmsSent) >= MIN_SMS_SEND_DELAY) {
+  if(!statusOK && checkElapsedDelay(now, lastSmsSent, MIN_SMS_SEND_DELAY)) {
     sendAlert();
     statusOK = true;
     lastSmsSent = now;
   }
 }
 
+// return true if current time is after given time + delay
+boolean checkElapsedDelay(unsigned long now, unsigned long lastTime, unsigned long delay) {
+  unsigned long elapsed = now - lastTime;
+  boolean result = false;
+
+  // millis() overflows unsigned long after about 50 days => 0
+  if(elapsed < 0) {
+    elapsed += 0xFFFFFFFFul;
+  }
+
+  if(elapsed >= delay) {
+    return true;
+  }
+  return result; 
+}
+
+// return true if temperature is within low and high thresholds
 boolean checkTemperature() {
   boolean temperatureOK = true;
   int highByte, lowByte, tReading, signBit, tc_100, whole, fract;
@@ -207,7 +311,7 @@ boolean checkTemperature() {
   return temperatureOK;
 }
 
-// Check the light level, compares it to the config-defined light threshold
+// Return true if light is above threshold
 boolean checkLight() {
   long lightLevel = 0;
   boolean lightOK = true;
@@ -218,7 +322,6 @@ boolean checkLight() {
     lightOK = false;
   }
   return(lightOK);
-  //return true;
 }
 
 // Check for incoming SMS, and processes it if any
@@ -237,14 +340,14 @@ void checkSMS() {
     sms.remoteNumber(from, 20);
     Serial.println(from);
 
-    // An example of message disposal
     // Any messages starting with # should be discarded
     if (sms.peek() == '#') {
       Serial.println(getProgMemMsg(DISCARD_SMS_MSG));
       sms.flush();
     } else {
-      // Read message bytes and print them
+      // Read message bytes
       while ((c = sms.read()) && (cptr < MAX_SMS_LENGTH)) {
+        // If uppercase, convert to lowercase
         if ((c > 64) && (c < 91)) {
           c = c + 32;
         }
@@ -255,25 +358,25 @@ void checkSMS() {
       sms.flush();
       
       Serial.println(msgIn);
-      if(strncmp(msgIn, "config", 6) == 0) {
+      if(strncmp(msgIn, "config", 6) == 0) {         // Sender wants to receive configuration
         sendConfig(from);
-      } else if(strncmp(msgIn, "temp ", 5) == 0) {
-        configTemperatureThresholds(from, msgIn);
-      } else if(strncmp(msgIn, "light ", 6) == 0) {
-        configLightThreshold(from, msgIn);
-      } else if(strncmp(msgIn, "save", 4) == 0) {
+      } else if(strncmp(msgIn, "temp ", 5) == 0) {   // Sender wants to set temperture thresholds
+        setTemperatureThresholds(from, msgIn);
+      } else if(strncmp(msgIn, "light ", 6) == 0) {  // Sender wants to set light threshold
+        setLightThreshold(from, msgIn);
+      } else if(strncmp(msgIn, "save", 4) == 0) {    // Sender wants config to be saved to EEPROM
         saveConfig(from);
-      } else if(strncmp(msgIn, "status", 6) == 0) {
+      } else if(strncmp(msgIn, "status", 6) == 0) {  // Sender wants to receive current measurements
         sendStatus(from);
-      } else if(strncmp(msgIn, "sub ", 3) == 0) {
+      } else if(strncmp(msgIn, "sub ", 3) == 0) {    // Sender wants to subscribe to given service
         subscribe(from, msgIn);
-      } else if(strncmp(msgIn, "unsub ",5) == 0) {
+      } else if(strncmp(msgIn, "unsub ",5) == 0) {   // Sender wants to unsuscrive to give service
         unsubscribe(from, msgIn);
-      } else if(strncmp(msgIn, "reset sub", 9) == 0) {
-        config.registeredNumbers[0].serviceFlags = 0xFF;
+      } else if(strncmp(msgIn, "reset sub", 9) == 0) {  // Sender wants to cancel all subscriptions
+        config.registeredNumbers[0].permissionFlags = 0xFF;
         strcpy(config.registeredNumbers[0].number, REMOTE_NUMBER);
         for(i=1 ; i < MAX_PHONE_NUMBERS; i++ ) {
-          config.registeredNumbers[i].serviceFlags = 0;
+          config.registeredNumbers[i].permissionFlags = 0;
           config.registeredNumbers[i].number[0] = 0;
         }
       }
@@ -281,6 +384,7 @@ void checkSMS() {
   }
 }
 
+// Return the flag for a given service name
 unsigned char getServiceFlagFromName(char *serviceName) {
   unsigned char serviceFlag = 0;
 
@@ -293,18 +397,19 @@ unsigned char getServiceFlagFromName(char *serviceName) {
   } else if(0 == strncmp(serviceName, "unsub", 5)) {
     serviceFlag = FLAG_SERVICE_UNSUB;
   }
-  Serial.println(serviceFlag);
   return serviceFlag;
 }
 
-void configLightThreshold(char *from, char *msgIn) {
+// Set the light threshold below which an alert will be sent
+void setLightThreshold(char *from, char *msgIn) {
   int threshold;
   sscanf(msgIn, "light %d", &threshold);
   config.lightThreshold = threshold;
   sendSMS(from, "Light threshold set");
 }
 
-void configTemperatureThresholds(char *from, char *msgIn) {
+// Set the temperatures thresholds below or above which an alert will be sent
+void setTemperatureThresholds(char *from, char *msgIn) {
   int low, high;
   sscanf(msgIn, "temp %d %d", &low, &high);
   config.temperatureHighThreshold = high;
@@ -312,6 +417,7 @@ void configTemperatureThresholds(char *from, char *msgIn) {
   sendSMS(from, "Temp thresholds set");
 }
 
+// Subscribe a number to a service
 void subscribe(char *number, char *msgIn) {
   unsigned char serviceFlag;
   unsigned char i, firstFree = MAX_PHONE_NUMBERS;
@@ -331,13 +437,13 @@ void subscribe(char *number, char *msgIn) {
       }
     } else if (0 == strncmp(config.registeredNumbers[i].number, number, PHONE_NUMBER_LENGTH)) {
       // If number found, set its flag for the given service
-      config.registeredNumbers[i].serviceFlags |= serviceFlag;
+      config.registeredNumbers[i].permissionFlags |= serviceFlag;
       done = true;
     }
     // If number was not yet registered but a free spot is available, register it
     if(!done && (firstFree < MAX_PHONE_NUMBERS)) {
       strncpy(config.registeredNumbers[firstFree].number, number, PHONE_NUMBER_LENGTH);
-      config.registeredNumbers[firstFree].serviceFlags = serviceFlag;
+      config.registeredNumbers[firstFree].permissionFlags = serviceFlag;
       done = true;
     }
   }
@@ -350,6 +456,7 @@ void subscribe(char *number, char *msgIn) {
   }
 }
 
+// Unsubscribe a user from a service
 void unsubscribe(char *number, char *msgIn) {
   unsigned char serviceFlag;
   unsigned char i;
@@ -363,9 +470,9 @@ void unsubscribe(char *number, char *msgIn) {
   for(i=0 ; i<MAX_PHONE_NUMBERS; i++) {
     if (0 == strncmp(config.registeredNumbers[i].number, number, PHONE_NUMBER_LENGTH)) {
       // If number found, cancel it
-      config.registeredNumbers[i].serviceFlags &= (~serviceFlag);
+      config.registeredNumbers[i].permissionFlags &= (~serviceFlag);
 
-      if(0 == config.registeredNumbers[i].serviceFlags) {
+      if(0 == config.registeredNumbers[i].permissionFlags) {
         config.registeredNumbers[i].number[0] = 0;
       }
       done = true;
@@ -386,7 +493,7 @@ void sendAlert() {
   print(0, 1, "Alerts");
   for(i=0; i < MAX_PHONE_NUMBERS; i++) {
     // If phone number initialized AND subscribed to the alert service
-    if((config.registeredNumbers[i].number[0] != 0) && (0 != (config.registeredNumbers[i].serviceFlags & FLAG_SERVICE_ALERT)) ) {
+    if((config.registeredNumbers[i].number[0] != 0) && (0 != (config.registeredNumbers[i].permissionFlags & FLAG_SERVICE_ALERT)) ) {
       sendStatus(config.registeredNumbers[i].number);
     }
   }
@@ -400,7 +507,9 @@ void sendStatus(char *toNumber) {
   sendSMS(toNumber, txtMsg);
 }
 
+// Send any kind of SMS to any give number
 void sendSMS(char *toNumber, char *message) {
+  if(toNumber[0] == 0) return;
   print(0, 0, getProgMemMsg(SENDING_SMS_MSG));
   print(0, 1, "To: ");
   print(4, 1, toNumber);
@@ -411,16 +520,17 @@ void sendSMS(char *toNumber, char *message) {
     sms.beginSMS(toNumber);
     sms.print(message);
     sms.endSMS();
-    print(0, 0, "SMS sent");
+    print(0, 0, getProgMemMsg(SMS_SENT_MSG));
   }
 }
 
-// Display a message on the LCD display
+// Display a message to Serial console and on the LCD display if supported
 void print(int col, int row, const char* displayMsg) {
+  Serial.println(displayMsg);
+#if WITH_LCD_SUPPORT
   char lcdBuf[LCD_WIDTH + 1];
   int cptr = 0;
   int count = strlen(displayMsg);
-  Serial.println(displayMsg);
 
   while((cptr < LCD_WIDTH) && (cptr < count)) {
     lcdBuf[cptr] = displayMsg[cptr];
@@ -434,52 +544,176 @@ void print(int col, int row, const char* displayMsg) {
 
   lcd.setCursor(col, row);
   lcd.print(lcdBuf);
+#endif
 }
 
+#if WITH_IR_SUPPORT
+// Remove the IR indicators from the LCD display
+void resetIRDisplay() {
+#if WITH_LCD_SUPPORT
+  //lcd.setCursor(14,0);
+  //lcd.print("  ");
+  lcd.setCursor(15,1);
+  lcd.print(" ");
+#endif
+}
+
+// Check if an IR code was received and process it according to its value
+void processIRCode(unsigned long code) {
+  char msgBuf[70];
+  if((irCode == IR_REPEAT_CODE) && (0 != previousCode)) {
+    irCode = previousCode;
+  }
+  previousCode = irCode;
+  lastIrDisplay = millis();
+  Serial.println(irCode, HEX);
+  //print(14, 0, "ir");
+  switch(irCode) {
+    case IR_DISPLAY_PHONE_NUMBER:
+      // TOTO loop over config
+    break;
+    case IR_INCR_LIGHT_THRESHOLD:
+      config.lightThreshold ++;
+      sprintf(msgBuf, getProgMemMsg(LIGHT_THRESHOLD_MSG_FORMAT), config.lightThreshold);
+      print(0, 1, msgBuf);
+    break;
+    case IR_DECR_LIGHT_THRESHOLD:
+      config.lightThreshold --;
+      sprintf(msgBuf, getProgMemMsg(LIGHT_THRESHOLD_MSG_FORMAT), config.lightThreshold);
+      print(0, 1, msgBuf);
+    break;
+
+    case IR_INCR_TEMP_ADJUSTMENT:
+      config.temperatureAdjustment ++;
+      sprintf(msgBuf, getProgMemMsg(TEMPERATURE_ADJUSTMENT_MSG_FORMAT), config.temperatureAdjustment);
+      print(0, 1, msgBuf);
+    break;
+    case IR_DECR_TEMP_ADJUSTMENT:
+      config.temperatureAdjustment --;
+      sprintf(msgBuf, getProgMemMsg(TEMPERATURE_ADJUSTMENT_MSG_FORMAT), config.temperatureAdjustment);
+      print(0, 1, msgBuf);
+    break;
+
+    case IR_DISPLAY_THRESHOLDS:
+      sprintf(msgBuf, getProgMemMsg(TEMPERATURE_THRESHOLD_MSG_FORMAT), config.temperatureLowThreshold, config.temperatureHighThreshold);
+      print(0, 0, msgBuf);
+      sprintf(msgBuf, getProgMemMsg(LIGHT_THRESHOLD_MSG_FORMAT), config.lightThreshold);
+      print(0, 1, msgBuf);
+    break;
+
+    case IR_DISPLAY_TEMP_ADJUST:
+      sprintf(msgBuf, getProgMemMsg(TEMPERATURE_ADJUSTMENT_MSG_FORMAT), config.temperatureAdjustment);
+      print(0, 0, msgBuf);
+    break;
+
+    case IR_SAVE_TO_EEPROM:
+      saveConfig("");
+    break;
+    case IR_LOG_CONFIG:
+      logConfig();
+    break;
+    default:
+      print(15, 1, "?");
+  }
+}
+
+// Log config to Serial console, on request from IR remote control
+void logConfig() {
+  char i;
+  for(i=0 ; i < MAX_PHONE_NUMBERS; i++ ) {
+    Serial.print(i);
+    Serial.print(" ");
+    Serial.print(config.registeredNumbers[i].number);
+    Serial.print(" ");
+    Serial.println(config.registeredNumbers[i].permissionFlags);
+  }
+}
+#endif
+
+// Send SMS with all configuration. Only if requesting number has the 'admin' flag set in config
 void sendConfig(char *toNumber) {
   char i;
   char message[40];
-  sms.beginSMS(toNumber);
 
-  sprintf(message, "Light threshold: %d, ", config.lightThreshold);
+  if(!checkAdmin(toNumber)) return;
+
+  sms.beginSMS(toNumber);
+  sprintf(message, getProgMemMsg(LIGHT_THRESHOLD_MSG_FORMAT), config.lightThreshold);
   sms.print(message);
-  sprintf(message, "Temp thresholds: %d %d, ", config.temperatureLowThreshold, config.temperatureHighThreshold);
+  sms.print(", ");
+  sprintf(message, getProgMemMsg(TEMPERATURE_THRESHOLD_MSG_FORMAT), config.temperatureLowThreshold, config.temperatureHighThreshold);
   sms.print(message);
+  sms.print(", ");
+  sprintf(message, getProgMemMsg(TEMPERATURE_ADJUSTMENT_MSG_FORMAT), config.temperatureAdjustment);
+  sms.print(message);
+  sms.print(", ");
   for(i=0 ; i < MAX_PHONE_NUMBERS; i++ ) {
     if(config.registeredNumbers[i].number[0] != 0) {
-      sprintf(message, "%s %2X,", config.registeredNumbers[i].number, config.registeredNumbers[i].serviceFlags);
+      sprintf(message, "%s %2X,", config.registeredNumbers[i].number, config.registeredNumbers[i].permissionFlags);
       sms.print(message);
     }
   }
   sms.endSMS();
 }
 
+// Return true/false depending on phone number having the admin flag
+boolean checkAdmin(char *number) {
+  boolean isAdmin = false;
+  char i;
+  for(i=0 ; i < MAX_PHONE_NUMBERS; i++ ) {
+    if(strncmp(config.registeredNumbers[i].number, number, PHONE_NUMBER_LENGTH)) {
+      if(config.registeredNumbers[i].permissionFlags & FLAG_ADMIN) {
+        isAdmin = true;
+        break;
+      }
+    }
+  }
+  return(isAdmin);
+}
+
+// Init config structure from EEPROM
+// If not in EEPROM or version has changed from what is stored in EEPROM, 
+// reset config to default values, and save it to EEPROM for next time
 void readConfig() {
   unsigned char i;
-  print(0, 1, "Read Config");
+  print(0, 1, getProgMemMsg(READING_CONFIG_MSG));
   EEPROM.readBlock(CONFIG_ADDRESS, config);
   if(config.version != CONFIG_VERSION) {
     config.version = CONFIG_VERSION;
-    config.lightThreshold = 500;
     config.temperatureAdjustment = 0;
     config.temperatureHighThreshold = 2700;
     config.temperatureLowThreshold = 2100;
+    config.lightThreshold = 200;
+    config.lightOnHour = 13;
+    config.lightOnMinute = 30;
+    config.lightOffHour = 20;
+    config.lightOffMinute = 30;
+
     // Reset all saved numbers
-    // First one is main number, hardcoded, and subscribed to all services
-    config.registeredNumbers[0].serviceFlags = 0xFF;
-    strcpy(config.registeredNumbers[0].number, REMOTE_NUMBER);
-    for(i=1 ; i < MAX_PHONE_NUMBERS; i++ ) {
-      config.registeredNumbers[i].serviceFlags = 0;
-      config.registeredNumbers[i].number[0] = 0;
+    // First one is main number, hardcoded, admin and subscribed to all services
+    for(i=0 ; i < MAX_PHONE_NUMBERS; i++ ) {
+      if(i == 0) {
+        config.registeredNumbers[i].permissionFlags = 0xFF;
+        strcpy(config.registeredNumbers[i].number, REMOTE_NUMBER);
+      } else {
+        config.registeredNumbers[i].permissionFlags = 0;
+        config.registeredNumbers[i].number[0] = 0;
+      }
+      config.registeredNumbers[i].lastAlertSmsTime = 0;
+      config.registeredNumbers[i].minAlertInterval = 60 * 30; // Every 30 minutes = 1800 seconds
     }
 
-    Serial.println("Saving");
-    EEPROM.writeBlock(CONFIG_ADDRESS, config);
+    // Should we automatically save ? or wait for a save request ?
+    saveConfig("");
   }
 }
 
+// Save the configuration to EEPROM
+// TODO : should that be for admin only ?
 void saveConfig(char *toNumber) {
-  print(0, 0, "Saving config");
+  print(0, 0, getProgMemMsg(SAVING_CONFIG_MSG));
   EEPROM.writeBlock(CONFIG_ADDRESS, config);
-  sendSMS(toNumber, "Config Saved");
+  sendSMS(toNumber, getProgMemMsg(CONFIG_SAVED_MSG));
 }
+
+

--- a/progmemStrings.h
+++ b/progmemStrings.h
@@ -28,7 +28,8 @@ const char numberNotUnsubscribedMsg[] PROGMEM = {"Unsub to %s failed: not found"
 const char savingConfigMsg[] PROGMEM = {"Saving config"};
 const char configSavedMsg[] PROGMEM = {"Config saved"};
 const char readingConfigMsg[] PROGMEM = {"Reading config"};
-
+const char accessDeniedMsg[] PROGMEM = {"Access denied"};
+const char unknownMsg[] PROGMEM = {"Unknown message"};
 
 #define INIT_AQUAMON_MSG 0
 #define INIT_IR_MSG 1
@@ -57,11 +58,13 @@ const char readingConfigMsg[] PROGMEM = {"Reading config"};
 #define SAVING_CONFIG_MSG 24
 #define CONFIG_SAVED_MSG 25
 #define READING_CONFIG_MSG 26
+#define ACCESS_DENIED_MSG 27
+#define UNKNOWN_MSG 28
 
 const char* const messages[] PROGMEM = {initAquamonMsg, initIRMsg, tempInitMsg, addrErrMsg, initGSMMsg, connectingGSMMsg,
    connectedGSMMsg, notConnectedGSMMsg, crcNotValidMsg, familyMsg, temperatureMsgFormat, lightMsgFormat, checkSMSMsg,
    fromNumberMsg, discardSMSMsg, sendingSMSMsg, SMSSentMsg, lightThresholdMsgFormat, temperatureAdjustmentMsgFormat,
    temperatureThresholdMsgFormat, numberSubscribedMsg, numberNotSubscribedMsg, numberUnsubscribedMsg, numberNotUnsubscribedMsg,
-   savingConfigMsg, configSavedMsg, readingConfigMsg,
+   savingConfigMsg, configSavedMsg, readingConfigMsg, accessDeniedMsg, unknownMsg,
 };
 

--- a/progmemStrings.h
+++ b/progmemStrings.h
@@ -17,6 +17,7 @@ const char checkSMSMsg[] PROGMEM = {"Checking SMS"};
 const char fromNumberMsg[] PROGMEM = {"Msg received from:"};
 const char discardSMSMsg[] PROGMEM = {"Discard SMS"};
 const char sendingSMSMsg[] PROGMEM = {"Sending SMS..."};
+const char SMSSentMsg[] PROGMEM = {"SMS sent"};
 const char lightThresholdMsgFormat[] PROGMEM = {"Light th: %d"};
 const char temperatureAdjustmentMsgFormat[] PROGMEM = {"Temp Adj: %d"};
 const char temperatureThresholdMsgFormat[] PROGMEM = {"Temp: %d %d"};
@@ -24,7 +25,9 @@ const char numberSubscribedMsg[] PROGMEM = {"Sub to %s done"};
 const char numberNotSubscribedMsg[] PROGMEM = {"Sub to %s failed: full"};
 const char numberUnsubscribedMsg[] PROGMEM = {"Unsub to %s done"};
 const char numberNotUnsubscribedMsg[] PROGMEM = {"Unsub to %s failed: not found"};
-
+const char savingConfigMsg[] PROGMEM = {"Saving config"};
+const char configSavedMsg[] PROGMEM = {"Config saved"};
+const char readingConfigMsg[] PROGMEM = {"Reading config"};
 
 
 #define INIT_AQUAMON_MSG 0
@@ -43,17 +46,22 @@ const char numberNotUnsubscribedMsg[] PROGMEM = {"Unsub to %s failed: not found"
 #define FROM_NUMBER_MSG 13
 #define DISCARD_SMS_MSG 14
 #define SENDING_SMS_MSG 15
-#define LIGHT_THRESHOLD_MSG_FORMAT 16
-#define TEMPERATURE_ADJUSTMENT_MSG_FORMAT 17
-#define TEMPERATURE_THRESHOLD_MSG_FORMAT 18
-#define NUMBER_SUBSCRIBED_MSG 19
-#define NUMBER_NOT_SUBSCRIBED_MSG 20
-#define NUMBER_UNSUBSCRIBED_MSG 21
-#define NUMBER_NOT_UNSUBSCRIBED_MSG 22
+#define SMS_SENT_MSG 16
+#define LIGHT_THRESHOLD_MSG_FORMAT 17
+#define TEMPERATURE_ADJUSTMENT_MSG_FORMAT 18
+#define TEMPERATURE_THRESHOLD_MSG_FORMAT 19
+#define NUMBER_SUBSCRIBED_MSG 20
+#define NUMBER_NOT_SUBSCRIBED_MSG 21
+#define NUMBER_UNSUBSCRIBED_MSG 22
+#define NUMBER_NOT_UNSUBSCRIBED_MSG 23
+#define SAVING_CONFIG_MSG 24
+#define CONFIG_SAVED_MSG 25
+#define READING_CONFIG_MSG 26
 
 const char* const messages[] PROGMEM = {initAquamonMsg, initIRMsg, tempInitMsg, addrErrMsg, initGSMMsg, connectingGSMMsg,
    connectedGSMMsg, notConnectedGSMMsg, crcNotValidMsg, familyMsg, temperatureMsgFormat, lightMsgFormat, checkSMSMsg,
-   fromNumberMsg, discardSMSMsg, sendingSMSMsg, lightThresholdMsgFormat, temperatureAdjustmentMsgFormat,
-   temperatureThresholdMsgFormat, numberSubscribedMsg, numberNotSubscribedMsg, numberUnsubscribedMsg, numberNotUnsubscribedMsg
+   fromNumberMsg, discardSMSMsg, sendingSMSMsg, SMSSentMsg, lightThresholdMsgFormat, temperatureAdjustmentMsgFormat,
+   temperatureThresholdMsgFormat, numberSubscribedMsg, numberNotSubscribedMsg, numberUnsubscribedMsg, numberNotUnsubscribedMsg,
+   savingConfigMsg, configSavedMsg, readingConfigMsg,
 };
 


### PR DESCRIPTION
IR support code was removed to make room for new features, due to lack of memory on arduino Uno.

Code is back and can be disabled by a #define (and commenting a library include, due to bug on Arduino IDE preprocessor)

So it's just one unified piece of code. To rule them all.
